### PR TITLE
Setup CI via Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: ruby
+rvm:
+  - 1.9.3
+  - 2.0.0
+  - 2.1.0
+  - 2.2.0
+  - jruby-19mode

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 antimony
 ========
 
+[![Gem Version](http://img.shields.io/gem/v/antimony.svg)](https://rubygems.org/gems/antimony)
+[![Build Status](http://img.shields.io/travis/manheim/antimony.svg)](https://travis-ci.org/manheim/antimony)
+[![License](http://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+
+
 Antimony is a DSL allowing developers to write automated workflows for TN5250 mainframe applications.
 
 ## Formulas


### PR DESCRIPTION
This sets up travis for common ruby versions and adds some badges to the readme. All pushes to master and PR's will automatically trigger builds and report their status.

To get it working, simply log into travis with the Manheim github account and connect the antimony repo.